### PR TITLE
Non-file Makefile targets should have .PHONY

### DIFF
--- a/sample/Makefile
+++ b/sample/Makefile
@@ -1,5 +1,6 @@
 COMMON=-O2 -I../include -L../bin -std=c++11 -mavx -pthread -Wl,-rpath,'$$ORIGIN'
 
+.PHONY: all
 all:
 	g++ $(COMMON) testxml.cc    -lmujoco210nogl                             -o ../bin/testxml
 	g++ $(COMMON) testspeed.cc  -lmujoco210nogl                             -o ../bin/testspeed

--- a/sample/Makefile.macos
+++ b/sample/Makefile.macos
@@ -1,5 +1,6 @@
 COMMON=-O2 -I../include -L../bin -std=c++11 -stdlib=libc++ -mavx -pthread
 
+.PHONY: all
 all:
 	clang++ $(COMMON) testxml.cc    -lmujoco210nogl      -o ../bin/testxml
 	clang++ $(COMMON) testspeed.cc  -lmujoco210nogl      -o ../bin/testspeed

--- a/sample/Makefile.windows
+++ b/sample/Makefile.windows
@@ -1,5 +1,6 @@
 COMMON=/O2 /MT /EHsc /arch:AVX /I../include /Fe../bin/
 
+.PHONY: all
 all:
 	cl $(COMMON) testxml.cc                 ../bin/mujoco210nogl.lib
 	cl $(COMMON) testspeed.cc               ../bin/mujoco210nogl.lib


### PR DESCRIPTION
- See https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html and https://stackoverflow.com/questions/2145590/what-is-the-purpose-of-phony-in-a-makefile for details
- Also, since [`.PHONY` targets are cumulative](https://lists.gnu.org/archive/html/help-make/2010-02/msg00118.html), it's often cleaner to declare the phony next to the command, instead of a giant blob