### PR TITLE
Allow MjGeoms positions to be anywhere when converted to free objects

### DIFF
--- a/unity/Editor/Components/MjGeomEditor.cs
+++ b/unity/Editor/Components/MjGeomEditor.cs
@@ -43,12 +43,14 @@ public class MjGeomEditor : MjShapeComponentEditor {
       return;
     }
     var parent = new GameObject(geom.gameObject.name + " Body").transform;
+    parent.position = geom.transform.position;
     var root = geom.transform.root;
     if (root != geom.transform) {
       parent.parent = geom.transform.parent;
     }
     parent.gameObject.AddComponent<MjBody>();
     var joint = new GameObject("Free Joint").AddComponent<MjFreeJoint>();
+    joint.transform.position = geom.transform.position;
     joint.transform.parent = parent;
     geom.transform.parent = parent;
   }


### PR DESCRIPTION
If you create a MJGeom move it into a position (other than the origin) and then convert it to a free object, it breaks the simulation. The body (parent) and free joint are created at the origin, while the geom is at a differnet location, on simulation jittery unusual behavior and oddness ensues. In the fix below I move the newly created GameObjects to the geoms position before parenting happens.