### PR TITLE
[WIP] Enhance UI experience of simulate.cc

### DIFF
--- a/sample/simulate.cc
+++ b/sample/simulate.cc
@@ -1315,7 +1315,7 @@ void uiEvent(mjuiState* state) {
       switch (it->itemid) {
         // Open XML/MJB
         case 0: {
-          auto fileName = pfd::open_file("Open XML/MJB", DEFAULT_PATH, { "*.mjb", "*.xml" }, pfd::opt::none).result();
+          auto fileName = pfd::open_file("Open XML/MJB", DEFAULT_PATH, { "XML Files", "*.xml", "MJB Files", "*.mjb"}, pfd::opt::none).result();
           if (!fileName.empty()) {
             mju::strcpy_arr(filename, fileName[0].c_str());
             loadmodel();
@@ -1324,7 +1324,7 @@ void uiEvent(mjuiState* state) {
         }
         // Save XML
         case 1: {
-          auto fileName = pfd::save_file("Save XML", DEFAULT_PATH, { "*.xml" }, pfd::opt::none).result();
+          auto fileName = pfd::save_file("Save XML", DEFAULT_PATH, { "XML Files", "*.xml" }, pfd::opt::none).result();
           if (!fileName.empty()) {
             if(fileName.substr(fileName.find_last_of(".") + 1) != "xml")
               fileName += ".xml";
@@ -1335,7 +1335,7 @@ void uiEvent(mjuiState* state) {
         }
         // Save MJB
         case 2: {
-          auto fileName = pfd::save_file("Save MJB", DEFAULT_PATH, { "*.mjb" }, pfd::opt::none).result();
+          auto fileName = pfd::save_file("Save MJB", DEFAULT_PATH, { "MJB Files", "*.mjb" }, pfd::opt::none).result();
           if (!fileName.empty()) {
             if(fileName.substr(fileName.find_last_of(".") + 1) != "mjb")
               fileName += ".mjb";
@@ -1345,7 +1345,7 @@ void uiEvent(mjuiState* state) {
         }
         // Print model
         case 3: {
-          auto fileName = pfd::save_file("Print Model", DEFAULT_PATH, { "*.txt" }, pfd::opt::none).result();
+          auto fileName = pfd::save_file("Print Model", DEFAULT_PATH, { "Text Files", "*.txt" }, pfd::opt::none).result();
           if (!fileName.empty()) {
             if(fileName.substr(fileName.find_last_of(".") + 1) != "txt")
               fileName += ".txt";
@@ -1355,7 +1355,7 @@ void uiEvent(mjuiState* state) {
         }
         // Print data
         case 4: {
-          auto fileName = pfd::save_file("Print Data", DEFAULT_PATH, { "*.txt" }, pfd::opt::none).result();
+          auto fileName = pfd::save_file("Print Data", DEFAULT_PATH, { "Text Files", "*.txt" }, pfd::opt::none).result();
           if (!fileName.empty()) {
             if(fileName.substr(fileName.find_last_of(".") + 1) != "txt")
               fileName += ".txt";

--- a/sample/simulate.cc
+++ b/sample/simulate.cc
@@ -23,13 +23,14 @@
 #include "uitools.h"
 
 #include "portable-file-dialogs.h"
-#include <filesystem>
-#define DEFAULT_PATH "."
 
 #include "array_safety.h"
 namespace mju = ::mujoco::sample_util;
 
 //-------------------------------- global -----------------------------------------------
+
+// Default path for file dialogs.
+#define DEFAULT_PATH "."
 
 const bool pfdAvailable = pfd::settings::available();
 
@@ -1315,7 +1316,7 @@ void uiEvent(mjuiState* state) {
       switch (it->itemid) {
         // Open XML/MJB
         case 0: {
-          auto fileName = pfd::open_file("Open XML/MJB", DEFAULT_PATH, { "XML Files", "*.xml", "MJB Files", "*.mjb"}, pfd::opt::none).result();
+          auto fileName = pfd::open_file("Open XML/MJB", DEFAULT_PATH, { "All Files", "*", "XML Files", "*.xml", "MJB Files", "*.mjb"}, pfd::opt::none).result();
           if (!fileName.empty()) {
             mju::strcpy_arr(filename, fileName[0].c_str());
             loadmodel();
@@ -1324,7 +1325,7 @@ void uiEvent(mjuiState* state) {
         }
         // Save XML
         case 1: {
-          auto fileName = pfd::save_file("Save XML", DEFAULT_PATH, { "XML Files", "*.xml" }, pfd::opt::none).result();
+          auto fileName = pfd::save_file("Save XML", DEFAULT_PATH, { "All Files", "*", "XML Files", "*.xml" }, pfd::opt::none).result();
           if (!fileName.empty()) {
             if(fileName.substr(fileName.find_last_of(".") + 1) != "xml")
               fileName += ".xml";
@@ -1335,7 +1336,7 @@ void uiEvent(mjuiState* state) {
         }
         // Save MJB
         case 2: {
-          auto fileName = pfd::save_file("Save MJB", DEFAULT_PATH, { "MJB Files", "*.mjb" }, pfd::opt::none).result();
+          auto fileName = pfd::save_file("Save MJB", DEFAULT_PATH, { "All Files", "*", "MJB Files", "*.mjb" }, pfd::opt::none).result();
           if (!fileName.empty()) {
             if(fileName.substr(fileName.find_last_of(".") + 1) != "mjb")
               fileName += ".mjb";
@@ -1345,7 +1346,7 @@ void uiEvent(mjuiState* state) {
         }
         // Print model
         case 3: {
-          auto fileName = pfd::save_file("Print Model", DEFAULT_PATH, { "Text Files", "*.txt" }, pfd::opt::none).result();
+          auto fileName = pfd::save_file("Print Model", DEFAULT_PATH, { "All Files", "*", "Text Files", "*.txt" }, pfd::opt::none).result();
           if (!fileName.empty()) {
             if(fileName.substr(fileName.find_last_of(".") + 1) != "txt")
               fileName += ".txt";
@@ -1355,7 +1356,7 @@ void uiEvent(mjuiState* state) {
         }
         // Print data
         case 4: {
-          auto fileName = pfd::save_file("Print Data", DEFAULT_PATH, { "Text Files", "*.txt" }, pfd::opt::none).result();
+          auto fileName = pfd::save_file("Print Data", DEFAULT_PATH, { "All Files", "*", "Text Files", "*.txt" }, pfd::opt::none).result();
           if (!fileName.empty()) {
             if(fileName.substr(fileName.find_last_of(".") + 1) != "txt")
               fileName += ".txt";


### PR DESCRIPTION
Fixes #110.

## Summary

- [x] You can press `Q` to quit the application.
- [x] Add `Open` button to File panel which opens up a file dialog box and allows the user to select XML/MJB files.
- [x] Add file dialog boxes to Save/Print buttons in the File panel.

File dialog functionality relies on the [portable-file-dialogs](https://github.com/samhocevar/portable-file-dialogs) header-only library, which is licensed under a very permissive [WTFPL License](https://github.com/samhocevar/portable-file-dialogs/blob/main/COPYING).

## Preview

**Open.**

https://user-images.githubusercontent.com/10518920/160301233-5c863d7d-e71f-43fc-be86-ccdcb9fcb61a.mp4

**Save.**

https://user-images.githubusercontent.com/10518920/160301177-9b2886fb-f5f9-4fb4-a076-37f42c9a7d50.mp4

## Tested

- [x] macOS M1
- [x] Ubuntu 20.04

## Alternatives

I also considered [tiny-file-dialogs](https://sourceforge.net/projects/tinyfiledialogs/), but it was crashing on M1.