### PR TITLE
Fixing sensor reading in Unity, expose Advanced Settings property in Editor and add Priority tag to geometry

### DIFF
--- a/unity/Editor/Components/MjGeomEditor.cs
+++ b/unity/Editor/Components/MjGeomEditor.cs
@@ -24,6 +24,7 @@ public class MjGeomEditor : MjShapeComponentEditor {
     serializedObject.Update();
     EditorGUILayout.PropertyField(serializedObject.FindProperty("Mass"));
     EditorGUILayout.PropertyField(serializedObject.FindProperty("Density"));
+    EditorGUILayout.PropertyField(serializedObject.FindProperty("Settings"));
     serializedObject.ApplyModifiedProperties();
     base.OnInspectorGUI();
   }

--- a/unity/Runtime/Components/Joints/MjHingeJoint.cs
+++ b/unity/Runtime/Components/Joints/MjHingeJoint.cs
@@ -30,6 +30,9 @@ namespace Mujoco {
     [Tooltip("Joint movement, in rad/sec. Read-only at play time.")]
     public float Velocity;
 
+    [Tooltip("The current joint angle without normalization, in radians. Read-only.")]
+    public double RawConfiguration;
+
     [Tooltip("Joint settings.")]
     public MjJointSettings Settings = MjJointSettings.Default;
 
@@ -42,7 +45,8 @@ namespace Mujoco {
     }
 
     public override unsafe void OnSyncState(MujocoLib.mjData_* data) {
-      var qpos = (float)data->qpos[QposAddress];
+      RawConfiguration = data->qpos[QposAddress];
+      var qpos = (float)RawConfiguration;
       Configuration = (qpos % (2 * Mathf.PI)) * Mathf.Rad2Deg;
       Velocity = (float)data->qvel[DofAddress];
     }

--- a/unity/Runtime/Components/Sensors/MjSiteVectorSensor.cs
+++ b/unity/Runtime/Components/Sensors/MjSiteVectorSensor.cs
@@ -69,7 +69,8 @@ public class MjSiteVectorSensor : MjBaseSensor {
   }
 
   public override unsafe void OnSyncState(MujocoLib.mjData_* data) {
-    SensorReading = MjEngineTool.UnityVector3(data->sensordata, _sensorAddress);
+    Vector3 mjReading = new Vector3((float)data->sensordata[_sensorAddress], (float)data->sensordata[_sensorAddress + 1], (float)data->sensordata[_sensorAddress + 2]);
+    SensorReading = MjEngineTool.UnityVector3(mjReading);
   }
 }
 }

--- a/unity/Runtime/Components/Shapes/MjGeomSettings.cs
+++ b/unity/Runtime/Components/Shapes/MjGeomSettings.cs
@@ -21,6 +21,11 @@ namespace Mujoco {
 // Advanced settings of MjGeom component.
 [Serializable]
 public struct MjGeomSettings {
+
+
+  [Tooltip("Priority")]
+  public int Priority;
+
   [Tooltip("Solver accuracy settings.")]
   public GeomSolver Solver;
 
@@ -38,6 +43,9 @@ public struct MjGeomSettings {
   };
 
   public void FromMjcf(XmlElement mjcf) {
+
+    Priority = (int) mjcf.GetFloatAttribute("priority", 0);
+
     // Contact filtering settings.
     Filtering.Contype = (int)mjcf.GetFloatAttribute("contype", CollisionFiltering.Default.Contype);
     Filtering.Conaffinity = (int)mjcf.GetFloatAttribute(
@@ -71,6 +79,8 @@ public struct MjGeomSettings {
   }
 
   public void ToMjcf(XmlElement mjcf) {
+    mjcf.SetAttribute("priority", $"{Priority}");
+
     // Contact filtering settings.
     mjcf.SetAttribute("contype", $"{Filtering.Contype}");
     mjcf.SetAttribute("conaffinity", $"{Filtering.Conaffinity}");


### PR DESCRIPTION
This PR makes some small fixes to the Unity plugin to make it work with our controller

If desired, I could split this PR up but that would be a bit of work.

- Fixed offsets for the sensor readings. The sensor offset was multiplied by 3 twice. (MjSiteVectorSensor.cs)
- Added advanced settings to MjGeomEditor to be able to tune contact parameters (MjGeomEditor.cs)
- Added a raw configuration field to the hinge joint with double precision, to allow reading the angle of a continous joint without normalization
- Added the priority field to geometry to allow setting geometry priority for collisions