### PR TITLE
Add annotations for length of a given array in mj* structs

### DIFF
--- a/include/mujoco/mjrender.h
+++ b/include/mujoco/mjrender.h
@@ -108,7 +108,7 @@ struct mjrContext_ {              // custom OpenGL context
 
   // texture objects and info
   int ntexture;                   // number of allocated textures
-  int textureType[100];           // type of texture (mjtTexture)
+  int textureType[100];           // type of texture (mjtTexture) (ntexture)
   unsigned int texture[100];      // texture names
 
   // displaylist starting positions
@@ -129,10 +129,10 @@ struct mjrContext_ {              // custom OpenGL context
 
   // skin VBOs
   int nskin;                      // number of skins
-  unsigned int* skinvertVBO;      // skin vertex position VBOs
-  unsigned int* skinnormalVBO;    // skin vertex normal VBOs
-  unsigned int* skintexcoordVBO;  // skin vertex texture coordinate VBOs
-  unsigned int* skinfaceVBO;      // skin face index VBOs
+  unsigned int* skinvertVBO;      // skin vertex position VBOs (nskin)
+  unsigned int* skinnormalVBO;    // skin vertex normal VBOs (nskin)
+  unsigned int* skintexcoordVBO;  // skin vertex texture coordinate VBOs (nskin)
+  unsigned int* skinfaceVBO;      // skin face index VBOs (nskin)
 
   // character info
   int charWidth[127];             // character widths: normal and shadow

--- a/include/mujoco/mjvisualize.h
+++ b/include/mujoco/mjvisualize.h
@@ -268,20 +268,20 @@ struct mjvScene_ {                // abstract scene passed to OpenGL renderer
   // abstract geoms
   int      maxgeom;               // size of allocated geom buffer
   int      ngeom;                 // number of geoms currently in buffer
-  mjvGeom* geoms;                 // buffer for geoms
-  int*     geomorder;             // buffer for ordering geoms by distance to camera
+  mjvGeom* geoms;                 // buffer for geoms (ngeom)
+  int*     geomorder;             // buffer for ordering geoms by distance to camera (ngeom)
 
   // skin data
   int      nskin;                 // number of skins
-  int*     skinfacenum;           // number of faces in skin
-  int*     skinvertadr;           // address of skin vertices
-  int*     skinvertnum;           // number of vertices in skin
-  float*   skinvert;              // skin vertex data
-  float*   skinnormal;            // skin normal data
+  int*     skinfacenum;           // number of faces in skin (nskin)
+  int*     skinvertadr;           // address of skin vertices (nskin)
+  int*     skinvertnum;           // number of vertices in skin (nskin)
+  float*   skinvert;              // skin vertex data (nskin)
+  float*   skinnormal;            // skin normal data (nskin)
 
   // OpenGL lights
   int      nlight;                // number of lights currently in buffer
-  mjvLight lights[mjMAXLIGHT];    // buffer for lights
+  mjvLight lights[mjMAXLIGHT];    // buffer for lights (nlight)
 
   // OpenGL cameras
   mjvGLCamera camera[2];          // left and right camera


### PR DESCRIPTION
This PR added necessary annotations, following what we did for mjData
and mjModel for length of the given array.

This is useful because my parser used this info to generate Swift interface:
https://github.com/liuliu/swift-mujoco/blob/main/Sources/codegen/main.swift#L297
such that the access to underlying array is bound-checked.

Please let me know if this makes sense. After this change, I can
successfully generate all mj* struct interfaces in Swift without problem
(with notable exception of mjui): https://github.com/liuliu/swift-mujoco/tree/main/Sources