### PR TITLE
Remove useless TINYOBJLOADER_IMPLEMENTATION definition when building MuJoCo with CMake

### DIFF
--- a/src/user/CMakeLists.txt
+++ b/src/user/CMakeLists.txt
@@ -25,3 +25,4 @@ set(MUJOCO_USER_SRCS
 )
 
 target_sources(mujoco PRIVATE ${MUJOCO_USER_SRCS})
+target_compile_definitions(mujoco PRIVATE MUJOCO_DO_NOT_DEFINE_TINYOBJLOADER_IMPLEMENTATION)

--- a/src/user/user_mesh.cc
+++ b/src/user/user_mesh.cc
@@ -25,7 +25,11 @@
 #include <string>
 #include <vector>
 
+// This macro is defined when MuJoCo is built with CMake,
+// not defined when MuJoCo is built with other build systems
+#ifndef MUJOCO_DO_NOT_DEFINE_TINYOBJLOADER_IMPLEMENTATION
 #define TINYOBJLOADER_IMPLEMENTATION
+#endif
 
 #include <mujoco/mjmodel.h>
 #include "cc/array_safety.h"


### PR DESCRIPTION
As far as I understand, `TINYOBJLOADER_IMPLEMENTATION` macro is used to be defined in libraries or executables that consume `tinyobjloader` only including its header, without linking the corresponding library. However mujoco (at least with the CMake build system provided in this repo) is already linking the tinyobjloader library in which all the symbols are defined, so there is no need to re-defined them.