### PR TITLE
Using CMAKE_CURRENT_SOURCE_DIR to refer to mujoco's include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ set(MUJOCO_HEADERS
 add_library(mujoco SHARED)
 target_include_directories(
   mujoco
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
   PRIVATE src
 )


### PR DESCRIPTION
With CMAKE_CURRENT_SOURCE_DIR mujoco will be able to compile as subproject with CMake's FetchContent feature.