### PR TITLE
Fix two asan detected memory bugs

### DIFF
--- a/src/engine/engine_print.c
+++ b/src/engine/engine_print.c
@@ -787,7 +787,7 @@ void mj_printFormattedData(const mjModel* m, mjData* d, const char* filename,
   printArray("ACT", m->na, 1, d->act, fp, float_format);
   printArray("QACC_WARMSTART", m->nv, 1, d->qacc_warmstart, fp, float_format);
   printArray("CTRL", m->nu, 1, d->ctrl, fp, float_format);
-  printArray("QFRC_APPLIED", m->nq, 1, d->qfrc_applied, fp, float_format);
+  printArray("QFRC_APPLIED", m->nv, 1, d->qfrc_applied, fp, float_format);
   printArray("XFRC_APPLIED", m->nbody, 6, d->xfrc_applied, fp, float_format);
   printArray("MOCAP_POS", m->nmocap, 3, d->mocap_pos, fp, float_format);
   printArray("MOCAP_QUAT", m->nmocap, 4, d->mocap_quat, fp, float_format);

--- a/src/render/render_gl2.c
+++ b/src/render/render_gl2.c
@@ -711,7 +711,7 @@ static void maketext(const char* format, char* txt, float num, int txt_sz) {
     }
 
     // '.' found: strip
-    if (txt[j]=='.') {
+    if (j>=0 && txt[j]=='.') {
       txt[i] = 0;
     }
   }


### PR DESCRIPTION
I am running through [simulate.swift](https://github.com/liuliu/swift-mujoco/blob/main/Examples/simulate/main.swift) (my port of simulate.cc) with
address sanitizer to discover related bugs.

Besides ones in my port, there are two in MuJoCo:

1. in maketext, the logic to find . is not protected against j is less
   than 0 (due to the decreasing logic above), creating out of bound
   access.

2. in mj_printFormattedData, qfrc_applied should use length nv not nq,
   otherwise out of bound access could be triggered.

Test Plan:

Run through the simulate.cc with asan. Before this fix, when presenting
profiler view, it will trigger bug #1. When print data, it will trigger
bug #2. Both are using model/humanoid/22_humanoids.xml.