### PR TITLE
Fix simulate condition variable predicate

### DIFF
--- a/simulate/simulate.cc
+++ b/simulate/simulate.cc
@@ -1574,7 +1574,7 @@ void Simulate::load(const char* file,
     // Wait for the render thread to be done loading
     // so that we know the old model and data's memory can
     // be free'd by the other thread (sometimes python)
-    cond_loadrequest.wait(lock, [this]() { return this->loadrequest > 0; });
+    cond_loadrequest.wait(lock, [this]() { return this->loadrequest == 0; });
   }
 }
 


### PR DESCRIPTION
The merge commit of #201 (e40b9da18120c73f5c26fcd3899d8b0ff5f21a2a) changed

 ```while (this->loadrequest > 0)```

to

```cond_loadrequest.wait(lock, [this]() { return this->loadrequest > 0; });```

but `wait` is equivalent to `while(!pred())` so it needs to be

```cond_loadrequest.wait(lock, [this]() { return this->loadrequest == 0; });```

or there is a race condition. Presumably this did not come up in testing because it only causes a segmentation fault when the caller of `load` function quickly destroys the `m` and `d` objects (which Python does and the pure C++ `simulate` does not).