### PR TITLE
Fix off by one in segmentation with IDCOLOR documentation

### DIFF
--- a/doc/APIreference.rst
+++ b/doc/APIreference.rst
@@ -873,7 +873,7 @@ mjtRndFlag
        mjRND_FOG,                      // fog
        mjRND_HAZE,                     // haze
        mjRND_SEGMENT,                  // segmentation with random color
-       mjRND_IDCOLOR,                  // segmentation with segid color
+       mjRND_IDCOLOR,                  // segmentation with segid+1 color
 
        mjNRNDFLAG                      // number of rendering flags
    } mjtRndFlag;

--- a/include/mujoco/mjvisualize.h
+++ b/include/mujoco/mjvisualize.h
@@ -133,7 +133,7 @@ typedef enum mjtRndFlag_ {        // flags enabling rendering effects
   mjRND_FOG,                      // fog
   mjRND_HAZE,                     // haze
   mjRND_SEGMENT,                  // segmentation with random color
-  mjRND_IDCOLOR,                  // segmentation with segid color
+  mjRND_IDCOLOR,                  // segmentation with segid+1 color
 
   mjNRNDFLAG                      // number of rendering flags
 } mjtRndFlag;


### PR DESCRIPTION
Figured this out while using the feature however it wasn't hard to find the `+1` [in the rendering code](https://github.com/deepmind/mujoco/blob/7a0e0ed80cf65aa4f5142b1ee197c1f0c0a44955/src/render/render_gl3.c#L265)
 as well.

The rendered color needs to be `segid+1` so that the value "0" can represent "nothing".