### PR TITLE
Swap out cp call with shutil.copyfile closes #462

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -246,8 +246,7 @@ class BuildCMakeExtension(build_ext.build_ext):
   def build_extension(self, ext):
     dest_path = self.get_ext_fullpath(ext.name)
     build_path = os.path.join(self.build_temp, os.path.basename(dest_path))
-    subprocess.check_call(['cp', build_path, dest_path])
-
+    shutil.copyfile(build_path, dest_path)
 
 def find_data_files(package_dir, patterns):
   """Recursively finds files whose names match the given shell patterns."""


### PR DESCRIPTION
Since `cp` is unavailable on Windows `setup.py` exits with an error. Using `shutil.copyfile` fixes it.