### PR TITLE
Fix MjWeld using wrong address in Unity plugin

### DIFF
--- a/unity/Runtime/Components/Equality/MjWeld.cs
+++ b/unity/Runtime/Components/Equality/MjWeld.cs
@@ -28,7 +28,7 @@ namespace Mujoco {
     protected override unsafe void OnBindToRuntime(MujocoLib.mjModel_* model, MujocoLib.mjData_* data) {
       if (WeldOffset) {
         MjEngineTool.SetMjTransform(
-            MjEngineTool.MjTransformAtEntry(model->eq_data, MujocoId),
+            MjEngineTool.MjEqualityAtEntry(model->eq_data, MujocoId)+3,
             WeldOffset.localPosition, WeldOffset.localRotation);
       }
     }

--- a/unity/Runtime/Tools/MjEngineTool.cs
+++ b/unity/Runtime/Tools/MjEngineTool.cs
@@ -106,7 +106,7 @@ public static class MjEngineTool {
   public static unsafe double* MjMatrixAtEntry(double* mjTarget, int offsetEntry) {
     return mjTarget + offsetEntry * _mjMat.Length;
   }
-  
+
   // Returns a pointer to an entry in the MuJoCo field that's 11*offsetEntry down the buffer.
   public static unsafe double* MjEqualityAtEntry(double* mjTarget, int offsetEntry) {
     return mjTarget + offsetEntry * _elementsPerEquality;

--- a/unity/Runtime/Tools/MjEngineTool.cs
+++ b/unity/Runtime/Tools/MjEngineTool.cs
@@ -27,6 +27,7 @@ public static class MjEngineTool {
   private const int _elementsPerPosition = 3;
   private const int _elementsPerRotation = 4;
   private const int _elementsPerTransform = 7;
+  private const int _elementsPerEquality = 11;
   private static double[] _mjQuat = new double[4];
   private static double[] _mjMat = new double[9];
 
@@ -104,6 +105,11 @@ public static class MjEngineTool {
   // Returns a pointer to an entry in the MuJoCo field that's 9*offsetEntry down the buffer.
   public static unsafe double* MjMatrixAtEntry(double* mjTarget, int offsetEntry) {
     return mjTarget + offsetEntry * _mjMat.Length;
+  }
+  
+  // Returns a pointer to an entry in the MuJoCo field that's 11*offsetEntry down the buffer.
+  public static unsafe double* MjEqualityAtEntry(double* mjTarget, int offsetEntry) {
+    return mjTarget + offsetEntry * _elementsPerEquality;
   }
 
   // Stores a unity transform (position+rotation) in a Mujoco target buffer.


### PR DESCRIPTION
Fix according to advice in #486. In case someone wants to test it, it should be noted that this version of the plugin does not work with the prebuilt 2.2.2 dll, I think due to recent changes to the bindings in 1e2a9a53bcca2e2bf6758b350db32346d132098d (is a new release coming?). I tested the changes with a 2.2.2 friendly version at [this fork](/Balint-H/mujoco).