### PR TITLE
build(makefile): Non-file Makefile targets should have .PHONY

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,12 +8,12 @@ SPHINXBUILD   = sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
 
+.PHONY: help
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
-
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+.PHONY: Makefile
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,12 +1,13 @@
 # Minimal makefile for Sphinx documentation
 
+.DEFAULT_GOAL := help
+
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
 
-# Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -4,6 +4,7 @@
 
 COMMON=-O2 -I../include -L../lib -std=c++17 -pthread -Wl,-no-as-needed -Wl,-rpath,'$$ORIGIN'/../lib
 
+.PHONY: all
 all:
 	$(CXX) $(COMMON) testxml.cc            -lmujoco          -o ../bin/testxml
 	$(CXX) $(COMMON) testspeed.cc          -lmujoco          -o ../bin/testspeed

--- a/sample/Makefile.macos
+++ b/sample/Makefile.macos
@@ -10,6 +10,7 @@ CFLAGS=-O2 -F$(MUJOCOPATH) -I$(GLFWROOT)/include -pthread
 CXXFLAGS=$(CFLAGS) -std=c++17 -stdlib=libc++
 ALLFLAGS=$(CXXFLAGS) -L$(GLFWROOT)/lib -Wl,-rpath,$(MUJOCOPATH)
 
+.PHONY: all
 all:
 	clang++ $(ALLFLAGS)    testxml.cc    -framework mujoco        -o testxml
 	clang++ $(ALLFLAGS)    testspeed.cc  -framework mujoco        -o testspeed

--- a/sample/Makefile.windows
+++ b/sample/Makefile.windows
@@ -8,6 +8,7 @@
 
 COMMON=/O2 /MT /EHsc /arch:AVX /I../include /Fe../bin/
 
+.PHONY: all
 all:
 	cl $(COMMON) testxml.cc                                ../lib/mujoco.lib
 	cl $(COMMON) testspeed.cc                              ../lib/mujoco.lib


### PR DESCRIPTION
- update of old/stale PR https://github.com/deepmind/mujoco/pull/31
- See https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html and https://stackoverflow.com/questions/2145590/what-is-the-purpose-of-phony-in-a-makefile for details
- Also, since [`.PHONY` targets are cumulative](https://lists.gnu.org/archive/html/help-make/2010-02/msg00118.html), it's often cleaner to declare the phony next to the command instead of a giant blob