### PR TITLE
Add new uvs to meshes created so textures and materials can be rendered correctly

### DIFF
--- a/unity/Runtime/Components/Shapes/MjMeshFilter.cs
+++ b/unity/Runtime/Components/Shapes/MjMeshFilter.cs
@@ -55,6 +55,12 @@ public class MjMeshFilter : MonoBehaviour {
     _meshFilter.sharedMesh = mesh;
     mesh.vertices = meshData.Item1;
     mesh.triangles = meshData.Item2;
+    Vector2[] uvs = new Vector2[mesh.vertices.Length];
+    for (int i = 0; i < uvs.Length; i++){
+      uvs[i] = new Vector2(mesh.vertices[i].x, mesh.vertices[i].z);
+    }
+    mesh.uv = uvs;
+    
     mesh.RecalculateNormals();
     mesh.RecalculateTangents();
   }


### PR DESCRIPTION
MjMeshFilter did not add appropriate UVs to the new mesh, hence all created meshes were rendered with a single solid colour, missing out on textures, normal maps etc. from their materials. Changes were added based on the Unity [documentation example](https://docs.unity3d.com/ScriptReference/Mesh-uv.html) for creating new meshes. 