### PR TITLE
Unity MjScene synchronisation events

### DIFF
--- a/unity/Runtime/Components/MjScene.cs
+++ b/unity/Runtime/Components/MjScene.cs
@@ -62,6 +62,8 @@ public class MjScene : MonoBehaviour {
       return _instance;
     }
   }
+  
+  public static bool InstanceExists { get => _instance != null; }
 
   public void Awake() {
     if (_instance == null) {


### PR DESCRIPTION
Due to originally submitting PR #253 from the main branch of my fork, the PR got bloated and outdated. I'm submitting this feature update on a separate branch now instead for easier merging.

 Additions:
- Events to subscribe for in `MjScene` that are called before, after, or inside the MuJoCo update. This allows explicit definition of order of execution purely in script, and allows processing of control values between kinematics and dynamics conveniently. This is helpful for example when training RL environments to ensure observations collected are up to date, and improve stability of some controllers.
- To aid the setup and shutdown processes in scenes sometimes it is necessary to check if the `MjScene` instance exist. However there was currently no public way for doing so without creating a new `MjScene` instance as a side effect if it does not exist. A property was added so this can be checked e.g. inside `OnDestroy()` of other components.