### PR TITLE
Fix disappearing meshes on Geom duplicates in Unity Editor

### DIFF
--- a/unity/Runtime/Components/Shapes/MjMeshFilter.cs
+++ b/unity/Runtime/Components/Shapes/MjMeshFilter.cs
@@ -32,6 +32,7 @@ public class MjMeshFilter : MonoBehaviour {
     _geom = GetComponent<MjShapeComponent>();
     _shapeChangeStamp = new Vector4(0, 0, 0, -1);
     _meshFilter = GetComponent<MeshFilter>();
+    _meshFilter.mesh = new Mesh();
   }
 
   protected void Update() {


### PR DESCRIPTION
Addresses issue mentioned by #507, except it solves it not by not deleting meshes in Edit mode (which we want to if the geom changed in edit mode), but by referencing a new mesh when the `MjMeshFilter` is first created. When the new `MeshFilter`'s `sharedMesh` is updated, edited or destroyed, the original geom will now be unaffected. This helps with copy-pasting/duplicating parts of the model quickly without needing to update the old geoms.