### PR TITLE
Remove unnecessary unit conversion in MjSlideJoint in Unity plugin

### DIFF
--- a/unity/Runtime/Components/Joints/MjSlideJoint.cs
+++ b/unity/Runtime/Components/Joints/MjSlideJoint.cs
@@ -43,8 +43,7 @@ namespace Mujoco {
     }
 
     public override unsafe void OnSyncState(MujocoLib.mjData_* data) {
-      var qpos = (float)data->qpos[QposAddress];
-      Configuration = (qpos % (2 * Mathf.PI)) * Mathf.Rad2Deg;
+      Configuration = (float)data->qpos[QposAddress];
       Velocity = (float)data->qvel[DofAddress];
     }
 


### PR DESCRIPTION
Fix typo in `OnSyncState` of `MjSlideJoints`, which previously converted length to degrees. 