### PR TITLE
DSO missing from command line?

### DIFF
--- a/simulate/Makefile
+++ b/simulate/Makefile
@@ -7,5 +7,5 @@ COMMON=-O2 -I../include -L../lib -pthread -Wl,-no-as-needed -Wl,-rpath,'$$ORIGIN
 all:
 	$(CXX) $(COMMON) -std=c++17 -c simulate.cc
 	$(CC)  $(COMMON) -std=c11   -c uitools.c
-	$(CXX) $(COMMON) -std=c++17 main.cc simulate.o uitools.o -lmujoco -lglfw -o ../bin/simulate
+	$(CXX) $(COMMON) -std=c++17 main.cc simulate.o uitools.o -lmujoco -lglfw -ldl -o ../bin/simulate
 	rm uitools.o simulate.o


### PR DESCRIPTION
Without this, throws an error:

System: WSL, Ubuntu 20.04
```
user@DESKTOP:/mnt/c/Users/User/Mujoco/simulate$ make
g++ -O2 -I../include -L../lib -pthread -Wl,-no-as-needed -Wl,-rpath,'$ORIGIN'/../lib -std=c++17 -c simulate.cc
cc  -O2 -I../include -L../lib -pthread -Wl,-no-as-needed -Wl,-rpath,'$ORIGIN'/../lib -std=c11   -c uitools.cc
cc1plus: warning: command line option ‘-std=c11’ is valid for C/ObjC but not for C++
g++ -O2 -I../include -L../lib -pthread -Wl,-no-as-needed -Wl,-rpath,'$ORIGIN'/../lib -std=c++17 main.cc simulate.o uitools.o -lmujoco -lglfw -o ../bin/simulate
main.cc:190:67: warning: ignoring attributes on template argument ‘int (*)(void*) noexcept’ [-Wignored-attributes]
  190 |   using unique_dlhandle = std::unique_ptr<void, decltype(&dlclose)>;
      |                                                                   ^
/usr/bin/ld: /tmp/ccL62ELj.o: undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:14: all] Error 1
```