### PR TITLE
Reuse existing mesh assets in MjMeshFilter

### DIFF
--- a/unity/Runtime/Components/Shapes/MjMeshFilter.cs
+++ b/unity/Runtime/Components/Shapes/MjMeshFilter.cs
@@ -48,6 +48,12 @@ public class MjMeshFilter : MonoBehaviour {
       throw new ArgumentException("Unsupported geom shape detected");
     }
 
+    if(_geom.ShapeType == MjShapeComponent.ShapeTypes.Mesh) { 
+      MjMeshShape meshShape = _geom.Shape as MjMeshShape;
+      _meshFilter.sharedMesh = meshShape.Mesh;
+      return;
+    }
+
     DisposeCurrentMesh();
 
     var mesh = new Mesh();
@@ -73,7 +79,7 @@ public class MjMeshFilter : MonoBehaviour {
   // Dynamically created meshes with no references are only disposed automatically on scene changes.
   // This prevents resource leaks in case the host environment doesn't reload scenes.
   private void DisposeCurrentMesh() {
-    if (_meshFilter.sharedMesh != null) {
+    if (_meshFilter.sharedMesh != null && _geom.ShapeType != MjShapeComponent.ShapeTypes.Mesh) {
 #if UNITY_EDITOR
       DestroyImmediate(_meshFilter.sharedMesh);
 #else


### PR DESCRIPTION
Change in the Unity plugin. If a Geom uses a mesh at import, its shape won't be procedurally changed in the editor, therefore the existing mesh asset created at import can be used instead of creating and storing one in the scene. This significantly improves scene load and unload times on mesh-heavy scenes with about an order of magnitude.