### PR TITLE
Update cmakelist to fix a link failure on riscv64 (Debian/Ubuntu)

### DIFF
--- a/simulate/simulate.h
+++ b/simulate/simulate.h
@@ -106,9 +106,9 @@ class MJSIMULATEAPI Simulate {
   int run = 1;
 
   // atomics for cross-thread messages
-  std::atomic_bool exitrequest = false;
-  std::atomic_bool droploadrequest = false;
-  std::atomic_bool screenshotrequest = false;
+  std::atomic_int exitrequest = false;
+  std::atomic_int droploadrequest = false;
+  std::atomic_int screenshotrequest = false;
   std::atomic_int uiloadrequest = 0;
 
   // loadrequest


### PR DESCRIPTION
Riscv64 needs -latomic to be added explicitly on link flags.

Since atomic is used directly, better link it explicitly

[67/71] : && /usr/bin/cmake -E rm -f lib/riscv64-linux-gnu/liblibsimulate.a && /usr/bin/ar qc lib/riscv64-linux-gnu/liblibsimulate.a  simulate/CMakeFiles/libsimulate.dir/glfw_dispatch.cc.o simulate/CMakeFiles/libsimulate.dir/simulate.cc.o simulate/CMakeFiles/libsimulate.dir/uitools.cc.o && /usr/bin/ranlib lib/riscv64-linux-gnu/liblibsimulate.a && : [68/71] /usr/bin/c++ -DEIGEN_MPL2_ONLY -DMJSIMULATE_STATIC -I/<<PKGBUILDDIR>>/simulate -I/<<PKGBUILDDIR>>/include -I/usr/include/libqhull_r -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -fdata-sections -ffunction-sections -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-sign-compare -Wno-stringop-overflow -Wno-stringop-truncation -std=c++17 -MD -MT simulate/CMakeFiles/simulate.dir/simulate.cc.o -MF simulate/CMakeFiles/simulate.dir/simulate.cc.o.d -o simulate/CMakeFiles/simulate.dir/simulate.cc.o -c /<<PKGBUILDDIR>>/simulate/simulate.cc
[69/71] : && /usr/bin/c++ -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wl,-Bsymbolic-functions -Wl,-z,relro     -Wl,--gc-sections simulate/CMakeFiles/simulate.dir/main.cc.o simulate/CMakeFiles/simulate.dir/glfw_dispatch.cc.o simulate/CMakeFiles/simulate.dir/simulate.cc.o simulate/CMakeFiles/simulate.dir/uitools.cc.o -o bin/simulate  -Wl,-rpath,"\$ORIGIN/../lib/riscv64-linux-gnu"  lib/riscv64-linux-gnu/liblibsimulate.a  lib/riscv64-linux-gnu/libmujoco.so.2.2.2  /usr/lib/riscv64-linux-gnu/libglfw.so.3.3  /usr/lib/riscv64-linux-gnu/liblodepng.so && :
FAILED: bin/simulate 
: && /usr/bin/c++ -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wl,-Bsymbolic-functions -Wl,-z,relro     -Wl,--gc-sections simulate/CMakeFiles/simulate.dir/main.cc.o simulate/CMakeFiles/simulate.dir/glfw_dispatch.cc.o simulate/CMakeFiles/simulate.dir/simulate.cc.o simulate/CMakeFiles/simulate.dir/uitools.cc.o -o bin/simulate  -Wl,-rpath,"\$ORIGIN/../lib/riscv64-linux-gnu"  lib/riscv64-linux-gnu/liblibsimulate.a  lib/riscv64-linux-gnu/libmujoco.so.2.2.2  /usr/lib/riscv64-linux-gnu/libglfw.so.3.3  /usr/lib/riscv64-linux-gnu/liblodepng.so && :
/usr/bin/ld: simulate/CMakeFiles/simulate.dir/simulate.cc.o: in function `std::__atomic_base<bool>::exchange(bool, std::memory_order)':
./obj-riscv64-linux-gnu/./simulate/simulate.cc:513: undefined reference to `__atomic_exchange_1'
collect2: error: ld returned 1 exit status
[70/71] /usr/bin/c++ -DEIGEN_MPL2_ONLY -I/<<PKGBUILDDIR>>/include -I/usr/include/libqhull_r -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -fdata-sections -ffunction-sections -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-sign-compare -Wno-stringop-overflow -Wno-stringop-truncation -std=c++17 -MD -MT sample/CMakeFiles/testxml.dir/testxml.cc.o -MF sample/CMakeFiles/testxml.dir/testxml.cc.o.d -o sample/CMakeFiles/testxml.dir/testxml.cc.o -c /<<PKGBUILDDIR>>/sample/testxml.cc
ninja: build stopped: subcommand failed.
dh_auto_build: error: cd obj-riscv64-linux-gnu && LC_ALL=C.UTF-8 ninja -j8 -v returned exit code 1
make: *** [debian/rules:4: build-arch] Error 25
dpkg-buildpackage: error: debian/rules build-arch subprocess returned exit status 2