### PR TITLE
Add .meta file to Bindings folder

### DIFF
--- a/unity/Editor/Bindings.meta
+++ b/unity/Editor/Bindings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a16affd12ca3323468b45cded3a3e64d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Missing file added to Unity Editor folder, so the folder is included if the MuJoCo is included through git URL instead of a local directory. In that case the package is treated immutable by Unity, and does not automatically add a .meta file. Fixes #481.