### PR TITLE
Fix size mismatch of mjd_transitionFD

### DIFF
--- a/python/mujoco/functions.cc
+++ b/python/mujoco/functions.cc
@@ -1137,16 +1137,16 @@ PYBIND11_MODULE(_functions, pymodule) {
          std::optional<Eigen::Ref<EigenArrayXX>> C,
          std::optional<Eigen::Ref<EigenArrayXX>> D) {
         if (A.has_value() &&
-            (A->rows() != 2*m->nv+m->na || A->cols() != 2*m->nv+m->na)) {
-          throw py::type_error("A should be of shape (2*nv+na, 2*nv+na)");
+            (A->rows() != m->nq+m->nv+m->na || A->cols() != m->nq+m->nv+m->na)) {
+          throw py::type_error("A should be of shape (nq+nv+na, nq+nv+na)");
         }
         if (B.has_value() &&
-            (B->rows() != 2*m->nv+m->na || B->cols() != m->nu)) {
-          throw py::type_error("B should be of shape (2*nv+na, nu)");
+            (B->rows() != m->nq+m->nv+m->na || B->cols() != m->nu)) {
+          throw py::type_error("B should be of shape (nq+nv+na, nu)");
         }
         if (C.has_value() &&
-            (C->rows() != m->nsensordata || C->cols() != 2*m->nv+m->na)) {
-          throw py::type_error("C should be of shape (nsensordata, 2*nv+na)");
+            (C->rows() != m->nsensordata || C->cols() != m->nq+m->nv+m->na)) {
+          throw py::type_error("C should be of shape (nsensordata, nq+nv+na)");
         }
         if (D.has_value() &&
             (D->rows() != m->nsensordata || D->cols() != m->nu)) {

--- a/src/engine/engine_derivative.c
+++ b/src/engine/engine_derivative.c
@@ -1464,10 +1464,10 @@ void mjd_smooth_vel(const mjModel *m, mjData *d) {
 // finite differenced Jacobian of  (next_state, sensors) = mj_step(state, control)
 //   all outputs are optional
 //   output dimensions (transposed w.r.t Control Theory convention):
-//     DyDq: (nv x 2*nv+na)
-//     DyDv: (nv x 2*nv+na)
-//     DyDa: (na x 2*nv+na)
-//     DyDu: (nu x 2*nv+na)
+//     DyDq: (nv x nq+nv+na)
+//     DyDv: (nv x nq+nv+na)
+//     DyDa: (na x nq+nv+na)
+//     DyDu: (nu x nq+nv+na)
 //     DsDq: (nv x nsensordata)
 //     DsDv: (nv x nsensordata)
 //     DsDa: (na x nsensordata)
@@ -1479,7 +1479,7 @@ void mjd_stepFD(const mjModel* m, mjData* d, mjtNum eps, mjtByte centered,
                 mjtNum* DyDq, mjtNum* DyDv, mjtNum* DyDa, mjtNum* DyDu,
                 mjtNum* DsDq, mjtNum* DsDv, mjtNum* DsDa, mjtNum* DsDu) {
   int nq = m->nq, nv = m->nv, na = m->na, nu = m->nu, ns = m->nsensordata;
-  int ndx = 2*nv+na;  // row length of Dy Jacobians
+  int ndx = nq+nv+na;  // row length of Dy Jacobians
   mjMARKSTACK;
 
   // states
@@ -1716,14 +1716,14 @@ void mjd_stepFD(const mjModel* m, mjData* d, mjtNum eps, mjtByte centered,
 //   d(x_next) = A*dx + B*du
 //   d(sensor) = C*dx + D*du
 //   required output matrix dimensions:
-//      A: (2*nv+na x 2*nv+na)
-//      B: (2*nv+na x nu)
-//      D: (nsensordata x 2*nv+na)
+//      A: (nq+nv+na x nq+nv+na)
+//      B: (nq+nv+na x nu)
+//      D: (nsensordata x nq+nv+na)
 //      C: (nsensordata x nu)
 void mjd_transitionFD(const mjModel* m, mjData* d, mjtNum eps, mjtByte centered,
                       mjtNum* A, mjtNum* B, mjtNum* C, mjtNum* D) {
-  int nv = m->nv, na = m->na, nu = m->nu, ns = m->nsensordata;
-  int ndx = 2*nv+na;  // row length of state Jacobians
+  int nq = m->nq, nv = m->nv, na = m->na, nu = m->nu, ns = m->nsensordata;
+  int ndx = nq+nv+na;  // row length of state Jacobians
 
   // stepFD() offset pointers, initialised to NULL
   mjtNum *DyDq, *DyDv, *DyDa, *DsDq, *DsDv, *DsDa;


### PR DESCRIPTION
Sometimes the nq not equal to nv, but mjd_transitionFD suppose they are.
- [engine_derivative.c]: fix mjd_transitionFD and mjd_stepFD
- [functions.cc]: fix mjd_transitionFD

Fix #645.