### PR TITLE
Don't access MjScene in OnDisable() if it doesn't exist

### DIFF
--- a/unity/Runtime/Components/MjComponent.cs
+++ b/unity/Runtime/Components/MjComponent.cs
@@ -99,7 +99,7 @@ public abstract class MjComponent : MonoBehaviour {
   }
 
   public void OnDisable() {
-    if (!_exiting) {
+    if (!_exiting && MjScene.InstanceExists) {
       MjScene.Instance.SceneRecreationAtLateUpdateRequested = true;
     }
   }


### PR DESCRIPTION
Previously `MjComponent`s requested scene rebuilding at `OnDisable()` from `MjScene` even if it was already destroyed during scene transition. This generated a new MjScene during Scene cleanup, which resulted in a non-breaking error message in the Editor (and I assume some undesired side-effects). 
