### PR TITLE
Fix ignored angle units of springref during Unity import

### DIFF
--- a/unity/Runtime/Components/Joints/MjJointSettings.cs
+++ b/unity/Runtime/Components/Joints/MjJointSettings.cs
@@ -72,7 +72,7 @@ namespace Mujoco {
       var springDamper = mjcf.GetVector2Attribute("springdamper", Vector2.zero);
       TimeConstant = springDamper.x;
       DampingRatio = springDamper.y;
-      EquilibriumPose = mjcf.GetFloatAttribute("springref", 0.0f);
+      EquilibriumPose = MjSceneImportSettings.AnglesInDegrees? mjcf.GetFloatAttribute("springref", 0.0f) : mjcf.GetFloatAttribute("springref", 0.0f) * Mathf.Rad2Deg;
       Damping = mjcf.GetFloatAttribute("damping", 0.0f);
       Stiffness = mjcf.GetFloatAttribute("stiffness", 0.0f);
     }


### PR DESCRIPTION
Partially fixes #654, applies multiplier depending on `MjSceneImportSettings.AnglesInDegrees`.