### PR TITLE
Fix infinite loop in `mj_deleteFileVFS`

### DIFF
--- a/src/engine/engine_vfs.c
+++ b/src/engine/engine_vfs.c
@@ -179,7 +179,7 @@ int mj_deleteFileVFS(mjVFS* vfs, const char* filename) {
       mju_free(vfs->filedata[i]);
 
       // scroll remaining files forward
-      for (int j = i; j < vfs->nfile - 1; ++j) {
+      for (int j=i; j<vfs->nfile-1; j++) {
         mjSTRNCPY(vfs->filename[j], vfs->filename[j+1]);
         vfs->filesize[j] = vfs->filesize[j+1];
         vfs->filedata[j] = vfs->filedata[j+1];

--- a/src/engine/engine_vfs.c
+++ b/src/engine/engine_vfs.c
@@ -179,10 +179,10 @@ int mj_deleteFileVFS(mjVFS* vfs, const char* filename) {
       mju_free(vfs->filedata[i]);
 
       // scroll remaining files forward
-      while (i<vfs->nfile-1) {
-        mjSTRNCPY(vfs->filename[i], vfs->filename[i+1]);
-        vfs->filesize[i] = vfs->filesize[i+1];
-        vfs->filedata[i] = vfs->filedata[i+1];
+      for (int j = i; j < vfs->nfile - 1; ++j) {
+        mjSTRNCPY(vfs->filename[j], vfs->filename[j+1]);
+        vfs->filesize[j] = vfs->filesize[j+1];
+        vfs->filedata[j] = vfs->filedata[j+1];
       }
 
       // set last to 0, for style

--- a/test/engine/engine_vfs_test.cc
+++ b/test/engine/engine_vfs_test.cc
@@ -29,17 +29,39 @@ using EngineVfsTest = MujocoTest;
 TEST_F(EngineVfsTest, AddFileVFS) {
   constexpr char path[] = "engine/testdata/";
   const std::string dir = GetTestDataFilePath(path);
-  std::string file = "refsite.xml";
+  std::string file1 = "activation.xml";
+  std::string file2 = "damper.xml";
+  std::string file3 = "refsite.xml";
 
-  std::FILE* fp = std::fopen((dir + file).c_str(), "r");
-  ASSERT_THAT(fp, NotNull()) << "Input file missing.";
-  std::fclose(fp);
+  std::FILE* fp1 = std::fopen((dir + file1).c_str(), "r");
+  ASSERT_THAT(fp1, NotNull()) << "Input file1 missing.";
+  std::fclose(fp1);
+
+  std::FILE* fp2 = std::fopen((dir + file2).c_str(), "r");
+  ASSERT_THAT(fp2, NotNull()) << "Input file2 missing.";
+  std::fclose(fp2);
+
+  std::FILE* fp3 = std::fopen((dir + file3).c_str(), "r");
+  ASSERT_THAT(fp3, NotNull()) << "Input file3 missing.";
+  std::fclose(fp3);
 
   auto mj_vfs = std::make_unique<mjVFS>();
   mj_defaultVFS(mj_vfs.get());
-  EXPECT_THAT(mj_addFileVFS(mj_vfs.get(), dir.c_str(), file.c_str()), 0);
+
+  EXPECT_THAT(mj_vfs->nfile, 0);
+  EXPECT_THAT(mj_addFileVFS(mj_vfs.get(), dir.c_str(), file1.c_str()), 0);
   EXPECT_THAT(mj_vfs->nfile, 1);
-  mj_deleteFileVFS(mj_vfs.get(), file.c_str());
+  EXPECT_THAT(mj_addFileVFS(mj_vfs.get(), dir.c_str(), file2.c_str()), 0);
+  EXPECT_THAT(mj_vfs->nfile, 2);
+  EXPECT_THAT(mj_addFileVFS(mj_vfs.get(), dir.c_str(), file3.c_str()), 0);
+  EXPECT_THAT(mj_vfs->nfile, 3);
+  mj_deleteFileVFS(mj_vfs.get(), file1.c_str());
+  EXPECT_THAT(mj_vfs->nfile, 2);
+  mj_deleteFileVFS(mj_vfs.get(), file2.c_str());
+  EXPECT_THAT(mj_vfs->nfile, 1);
+  mj_deleteFileVFS(mj_vfs.get(), file3.c_str());
+  EXPECT_THAT(mj_vfs->nfile, 0);
+
   mj_deleteVFS(mj_vfs.get());
 }
 

--- a/test/engine/engine_vfs_test.cc
+++ b/test/engine/engine_vfs_test.cc
@@ -51,15 +51,29 @@ TEST_F(EngineVfsTest, AddFileVFS) {
   EXPECT_THAT(mj_vfs->nfile, 0);
   EXPECT_THAT(mj_addFileVFS(mj_vfs.get(), dir.c_str(), file1.c_str()), 0);
   EXPECT_THAT(mj_vfs->nfile, 1);
+  EXPECT_THAT(mj_vfs->filename[0], file1);
+
   EXPECT_THAT(mj_addFileVFS(mj_vfs.get(), dir.c_str(), file2.c_str()), 0);
   EXPECT_THAT(mj_vfs->nfile, 2);
+  EXPECT_THAT(mj_vfs->filename[0], file1);
+  EXPECT_THAT(mj_vfs->filename[1], file2);
+
   EXPECT_THAT(mj_addFileVFS(mj_vfs.get(), dir.c_str(), file3.c_str()), 0);
   EXPECT_THAT(mj_vfs->nfile, 3);
+  EXPECT_THAT(mj_vfs->filename[0], file1);
+  EXPECT_THAT(mj_vfs->filename[1], file2);
+  EXPECT_THAT(mj_vfs->filename[2], file3);
+
   mj_deleteFileVFS(mj_vfs.get(), file1.c_str());
   EXPECT_THAT(mj_vfs->nfile, 2);
-  mj_deleteFileVFS(mj_vfs.get(), file2.c_str());
-  EXPECT_THAT(mj_vfs->nfile, 1);
+  EXPECT_THAT(mj_vfs->filename[0], file2);
+  EXPECT_THAT(mj_vfs->filename[1], file3);
+
   mj_deleteFileVFS(mj_vfs.get(), file3.c_str());
+  EXPECT_THAT(mj_vfs->nfile, 1);
+  EXPECT_THAT(mj_vfs->filename[0], file2);
+
+  mj_deleteFileVFS(mj_vfs.get(), file2.c_str());
   EXPECT_THAT(mj_vfs->nfile, 0);
 
   mj_deleteVFS(mj_vfs.get());


### PR DESCRIPTION
In its current form, the `mj_deleteFileVFS` results in infinite loop with more than one file. This should fix the issue.