### PR TITLE
Add support for loading balloons.xml in Unity plugin

### DIFF
--- a/unity/Runtime/Components/Bodies/MjBody.cs
+++ b/unity/Runtime/Components/Bodies/MjBody.cs
@@ -20,17 +20,23 @@ namespace Mujoco {
 
   // The component represents the apex of hierarchy that defines a single rigid body.
   public class MjBody : MjBaseBody {
+
+    [Tooltip("Gravity compensation force, specified as fraction of body weight.")]
+    public float GravityCompensation;
+
     protected override void OnParseMjcf(XmlElement mjcf) {
       // Transform
       transform.localPosition =
           MjEngineTool.UnityVector3(mjcf.GetVector3Attribute("pos", defaultValue: Vector3.zero));
       transform.localRotation = MjEngineTool.UnityQuaternion(
           mjcf.GetQuaternionAttribute("quat", defaultValue: MjEngineTool.MjQuaternionIdentity));
+      GravityCompensation = mjcf.GetFloatAttribute("gravcomp", defaultValue: 0.0f);
     }
 
     protected override XmlElement OnGenerateMjcf(XmlDocument doc) {
       var mjcf = (XmlElement)doc.CreateElement("body");
       MjEngineTool.PositionRotationToMjcf(mjcf, this);
+      mjcf.SetAttribute("gravcomp", MjEngineTool.MakeLocaleInvariant($"{GravityCompensation}"));
       return mjcf;
     }
 

--- a/unity/Runtime/Components/MjGlobalSettings.cs
+++ b/unity/Runtime/Components/MjGlobalSettings.cs
@@ -29,7 +29,8 @@ namespace Mujoco {
 // exactly what the documentation specifies: http://mujoco.org/book/XMLreference.html#option .
 public enum IntegratorType {
   Euler,
-  RK4
+  RK4,
+  @implicit
 }
 
 public enum CollisionCheckType {

--- a/unity/Runtime/Components/MjGlobalSettings.cs
+++ b/unity/Runtime/Components/MjGlobalSettings.cs
@@ -209,7 +209,7 @@ public struct MjOptionStruct {
   public static MjOptionStruct Default = new MjOptionStruct() {
     ImpRatio = 1.0f,
     Magnetic = Vector3.zero,
-    Wind = new Vector3(0.0f, -0.5f, 0.0f),
+    Wind = new Vector3(0.0f, 0.0f, 0.0f),
     Density = 0.0f,
     Viscosity = 0.0f,
     OverrideMargin = 0.0f,

--- a/unity/Runtime/Importer/MjXmlModifiers.cs
+++ b/unity/Runtime/Importer/MjXmlModifiers.cs
@@ -28,12 +28,17 @@ namespace Mujoco {
       _root = root;
     }
 
-    public void ApplyModifiersToElement(XmlElement element) {
+    public void ApplyModifiersToElement(XmlElement element, string elementName=null) {
+      // Allow overriding the element name for defaults lookup, needed for tendon
+      if (elementName == null) {
+        elementName = element.Name;
+      }
+
       // Combine all defaults into one. At this stage, we want to overwrite attributes defined by
       // the previous defaults.
       var aggregateDefaults = _root.CreateElement("aggregate");
       // Root default leaf should be processed only once, and handled first (so it's overriden).
-      var rootDefaultLeaf = _root.SelectSingleNode($"/mujoco/default/{element.Name}") as XmlElement;
+      var rootDefaultLeaf = _root.SelectSingleNode($"/mujoco/default/{elementName}") as XmlElement;
       if (rootDefaultLeaf != null) {
         CopyAttributes(rootDefaultLeaf, aggregateDefaults);
       }
@@ -43,7 +48,7 @@ namespace Mujoco {
         var defaultClassElement =
             _root.SelectSingleNode($"descendant::default[@class='{className}']") as XmlElement;
         // Ancestry iterates up in the tree, but we want to apply changes from remote to specific.
-        var ancestors = GetDefaultAncestry(defaultClassElement, element.Name).Reverse();
+        var ancestors = GetDefaultAncestry(defaultClassElement, elementName).Reverse();
         foreach (var defaultAncestor in ancestors) {
           CopyAttributesOverwriteExisting(defaultAncestor, aggregateDefaults);
         }

--- a/unity/Runtime/Importer/MjcfImporter.cs
+++ b/unity/Runtime/Importer/MjcfImporter.cs
@@ -239,7 +239,7 @@ public class MjcfImporter {
     }
   }
 
-  // Called by ParseBodyChildren for each XML node, overridable by inheriting claases.
+  // Called by ParseBodyChildren for each XML node, overridable by inheriting classes.
   private void ParseBodyChild(XmlElement child, GameObject parentObject) {
     switch (child.Name) {
       case "geom": {

--- a/unity/Runtime/Importer/MjcfImporter.cs
+++ b/unity/Runtime/Importer/MjcfImporter.cs
@@ -167,6 +167,7 @@ public class MjcfImporter {
     if (tendonNode != null) {
       var tendonsParentObject = CreateGameObjectInParent("tendons", rootObject);
       foreach (var child in tendonNode.OfType<XmlElement>()) {
+        _modifiers.ApplyModifiersToElement(child, elementName: "tendon");
         if (child.Name == "fixed") {
           CreateGameObjectWithUniqueName<MjFixedTendon>(tendonsParentObject, child);
         } else if (child.Name == "spatial") {


### PR DESCRIPTION
Hi everyone, first timer here! 👋
When testing out MuJoCo I noticed that the balloons model didn't load for me with the unity plugin, so here's a patch which makes it work.

Let me know if you have any feedback 🙂 

---

Steps to reproduce the issue, in unity with plugin setup correctly:
1. Try to load the model located at `model/balloons/balloons.xml`

Result: It fails to load

---

The issues, causing it not to work in unity as expected, was:
* Missing support for the `implicit` integrator type - model failed to load before
* Missing support for `gravcomp` - balloons where just falling down
* Default wind in imported scene - not matching the stand alone simulator, nor the documentation
* The importer skipped defaults for tendons - the strings attaching the balloons to the weight wasn't fixed in length due to missing `limited="true"` attribute

I also fixed a typo in a comment in close proximity to one of the fixes. Let me know if you would prefer this fix to be separated to a new pull request instead.