### PR TITLE
Add support for fluid shapes to Unity plugin

### DIFF
--- a/unity/Runtime/Components/Shapes/MjGeomSettings.cs
+++ b/unity/Runtime/Components/Shapes/MjGeomSettings.cs
@@ -42,12 +42,17 @@ public struct MjGeomSettings {
   [Tooltip("Shape used for fluid simulation.")]
   public FluidShapeTypes FluidShapeType;
 
+  [Tooltip("Dimensionless coefficients of fluid interaction model.")]
+  public GeomFluidCoefficients FluidCoefficients;
+
+
   // Default geom settings.
   public static MjGeomSettings Default = new MjGeomSettings() {
     Solver = GeomSolver.Default,
     Filtering = CollisionFiltering.Default,
     Friction = GeomFriction.Default,
-    FluidShapeType = FluidShapeTypes.None
+    FluidShapeType = FluidShapeTypes.None,
+    FluidCoefficients = GeomFluidCoefficients.Default
   };
 
   public void FromMjcf(XmlElement mjcf) {
@@ -85,9 +90,19 @@ public struct MjGeomSettings {
     Friction.Torsional = friction[1];
     Friction.Rolling = friction[2];
 
-    // Fluid shape settings.
+    // Fluid settings.
     FluidShapeType = mjcf.GetEnumAttribute<FluidShapeTypes>(
         "fluidshape", FluidShapeTypes.None, ignoreCase: true);
+    var fluidcoef = mjcf.GetFloatArrayAttribute("fluidcoef", new float[] {
+        GeomFluidCoefficients.Default.BluntDrag, GeomFluidCoefficients.Default.SlenderDrag,
+        GeomFluidCoefficients.Default.AngularDrag, GeomFluidCoefficients.Default.KuttaLift,
+        GeomFluidCoefficients.Default.MagnusLift
+    });
+    FluidCoefficients.BluntDrag = fluidcoef[0];
+    FluidCoefficients.SlenderDrag = fluidcoef[1];
+    FluidCoefficients.AngularDrag = fluidcoef[2];
+    FluidCoefficients.KuttaLift = fluidcoef[3];
+    FluidCoefficients.MagnusLift = fluidcoef[4];
   }
 
   public void ToMjcf(XmlElement mjcf) {
@@ -110,8 +125,10 @@ public struct MjGeomSettings {
     // Inertia and friction settings.
     mjcf.SetAttribute("friction", MjEngineTool.MakeLocaleInvariant($"{Friction.Sliding} {Friction.Torsional} {Friction.Rolling}"));
 
-    // Fluid shape settings.
+    // Fluid settings.
     mjcf.SetAttribute("fluidshape", FluidShapeType.ToString().ToLower());
+    mjcf.SetAttribute("fluidcoef", MjEngineTool.MakeLocaleInvariant(
+      $"{FluidCoefficients.BluntDrag} {FluidCoefficients.SlenderDrag} {FluidCoefficients.AngularDrag} {FluidCoefficients.KuttaLift} {FluidCoefficients.MagnusLift}"));
   }
 }
 
@@ -168,6 +185,19 @@ public struct GeomSolver {
   public static GeomSolver Default = new GeomSolver() {
     ConDim = 3, SolMix = 1.0f, SolRef = SolverReference.Default, SolImp = SolverImpedance.Default,
     Margin = 0.0f, Gap = 0.0f
+  };
+}
+
+[Serializable]
+public struct GeomFluidCoefficients {
+  public float BluntDrag;
+  public float SlenderDrag;
+  public float AngularDrag;
+  public float KuttaLift;
+  public float MagnusLift;
+
+  public static GeomFluidCoefficients Default = new GeomFluidCoefficients() {
+    BluntDrag = 5f, SlenderDrag = .25f, AngularDrag = 1.5f, KuttaLift = 1f, MagnusLift = 1f
   };
 }
 }

--- a/unity/Runtime/Components/Shapes/MjGeomSettings.cs
+++ b/unity/Runtime/Components/Shapes/MjGeomSettings.cs
@@ -22,6 +22,10 @@ namespace Mujoco {
 [Serializable]
 public struct MjGeomSettings {
 
+  public enum FluidShapeTypes {
+    None,
+    Ellipsoid,
+  }
 
   [Tooltip("Priority")]
   public int Priority;
@@ -35,11 +39,15 @@ public struct MjGeomSettings {
   [Tooltip("Contact friction parameters for dynamically generated contact pairs.")]
   public GeomFriction Friction;
 
+  [Tooltip("Shape used for fluid simulation.")]
+  public FluidShapeTypes FluidShapeType;
+
   // Default geom settings.
   public static MjGeomSettings Default = new MjGeomSettings() {
     Solver = GeomSolver.Default,
     Filtering = CollisionFiltering.Default,
-    Friction = GeomFriction.Default
+    Friction = GeomFriction.Default,
+    FluidShapeType = FluidShapeTypes.None
   };
 
   public void FromMjcf(XmlElement mjcf) {
@@ -76,6 +84,10 @@ public struct MjGeomSettings {
     Friction.Sliding = friction[0];
     Friction.Torsional = friction[1];
     Friction.Rolling = friction[2];
+
+    // Fluid shape settings.
+    FluidShapeType = mjcf.GetEnumAttribute<FluidShapeTypes>(
+        "fluidshape", FluidShapeTypes.None, ignoreCase: true);
   }
 
   public void ToMjcf(XmlElement mjcf) {
@@ -97,6 +109,9 @@ public struct MjGeomSettings {
 
     // Inertia and friction settings.
     mjcf.SetAttribute("friction", MjEngineTool.MakeLocaleInvariant($"{Friction.Sliding} {Friction.Torsional} {Friction.Rolling}"));
+
+    // Fluid shape settings.
+    mjcf.SetAttribute("fluidshape", FluidShapeType.ToString().ToLower());
   }
 }
 

--- a/unity/Tests/Editor/Components/MjGeomSettingsTests.cs
+++ b/unity/Tests/Editor/Components/MjGeomSettingsTests.cs
@@ -116,6 +116,17 @@ public class MjGeomSettingsGenerationTests {
     _settings.ToMjcf(_mjcf);
     Assert.That(_doc.OuterXml, Does.Contain(@"fluidshape=""ellipsoid"""));
   }
+
+  [Test]
+  public void FluidCoefficientsMjcf() {
+    _settings.FluidCoefficients.BluntDrag = 2f;
+    _settings.FluidCoefficients.SlenderDrag = 3f;
+    _settings.FluidCoefficients.AngularDrag = 4f;
+    _settings.FluidCoefficients.KuttaLift = 5f;
+    _settings.FluidCoefficients.MagnusLift = 6f;
+    _settings.ToMjcf(_mjcf);
+    Assert.That(_doc.OuterXml, Does.Contain(@"fluidcoef=""2 3 4 5 6"""));
+  }
 }
 
 [TestFixture]
@@ -214,6 +225,17 @@ public class MjGeomSettingsParsingTests {
     Assert.That(_settings.FluidShapeType, Is.EqualTo(
         MjGeomSettings.FluidShapeTypes.Ellipsoid
     ));
+  }
+
+  [Test]
+  public void FluidCoefficientsMjcf() {
+    _mjcf.SetAttribute("fluidcoef", "2 3 4 5 6");
+    _settings.FromMjcf(_mjcf);
+    Assert.That(_settings.FluidCoefficients.BluntDrag, Is.EqualTo(2));
+    Assert.That(_settings.FluidCoefficients.SlenderDrag, Is.EqualTo(3));
+    Assert.That(_settings.FluidCoefficients.AngularDrag, Is.EqualTo(4));
+    Assert.That(_settings.FluidCoefficients.KuttaLift, Is.EqualTo(5));
+    Assert.That(_settings.FluidCoefficients.MagnusLift, Is.EqualTo(6));
   }
 }
 }

--- a/unity/Tests/Editor/Components/MjGeomSettingsTests.cs
+++ b/unity/Tests/Editor/Components/MjGeomSettingsTests.cs
@@ -109,6 +109,13 @@ public class MjGeomSettingsGenerationTests {
     _settings.ToMjcf(_mjcf);
     Assert.That(_doc.OuterXml, Does.Contain(@"friction=""5 6 7"""));
   }
+
+  [Test]
+  public void FluidShapeTypeMjcf() {
+    _settings.FluidShapeType = MjGeomSettings.FluidShapeTypes.Ellipsoid;
+    _settings.ToMjcf(_mjcf);
+    Assert.That(_doc.OuterXml, Does.Contain(@"fluidshape=""ellipsoid"""));
+  }
 }
 
 [TestFixture]
@@ -198,6 +205,15 @@ public class MjGeomSettingsParsingTests {
     Assert.That(_settings.Friction.Sliding, Is.EqualTo(5));
     Assert.That(_settings.Friction.Torsional, Is.EqualTo(6));
     Assert.That(_settings.Friction.Rolling, Is.EqualTo(7));
+  }
+
+  [Test]
+  public void FluidShapeTypeMjcf() {
+    _mjcf.SetAttribute("fluidshape", "ellipsoid");
+    _settings.FromMjcf(_mjcf);
+    Assert.That(_settings.FluidShapeType, Is.EqualTo(
+        MjGeomSettings.FluidShapeTypes.Ellipsoid
+    ));
   }
 }
 }


### PR DESCRIPTION
## Background
~~Tying a buoyant object to the world off center (horizontal offset to CoM), results currently in a never ending oscillation, even if the global settings specifies a viscosity and mass + density are specified.~~ [Edit: This was not the case, see discussion]

## The problem
In the XML Reference, there's a `fluidshape` attribute that can be used to introduce drag, but this feature is not exposed in the Unity Plugin, nor is it implied.

## Implementation
I've exposed the `fluidshape` attribute for a `geom` as `FluidShapeType` in `MjGeomSettings`, as this is where more advanced settings for geometries are placed. I assume you want it to be placed here to simplify the ux for new users, but let me know if you prefer it directly in `MjGeom`.

The name `FluidShapeType` isn't a 1:1 mapping to the XML attribute, but the naming tries to conform to the style used when `ShapeType` was named.
In my opinion, it's more important that it looks similar to `ShapeType` then being called the same was as in XML.