### PR TITLE
Ensure that loaded plugins are a shared library

### DIFF
--- a/python/mujoco/__init__.py
+++ b/python/mujoco/__init__.py
@@ -61,8 +61,8 @@ def _load_all_bundled_plugins():
             pass
 
         else:
-            raise ValueError(f"Trying to load the plugin {os.path.join(directory, filename)}, "
-                             "which is not a shared library.")
+            raise ValueError(f"Trying to load the plugin {os.path.join(directory, filename)} "
+                             "that is not a shared library.")
 
 _load_all_bundled_plugins()
 

--- a/python/mujoco/__init__.py
+++ b/python/mujoco/__init__.py
@@ -19,6 +19,7 @@ import ctypes.util
 import os
 import platform
 import subprocess
+import warnings
 
 _SYSTEM = platform.system()
 if _SYSTEM == 'Windows':
@@ -54,15 +55,13 @@ PLUGIN_HANDLES = []
 def _load_all_bundled_plugins():
   for directory, _, filenames in os.walk(PLUGINS_DIR):
     for filename in filenames:
-        if os.path.splitext(filename)[-1] == ".so":
-            PLUGIN_HANDLES.append(ctypes.CDLL(os.path.join(directory, filename)))
-
-        elif filename == "__init__.py":
-            pass
-
-        else:
-            raise ValueError(f"Trying to load the plugin {os.path.join(directory, filename)} "
-                             "that is not a shared library.")
+      if os.path.splitext(filename)[-1] in [".dll", ".dylib", ".so"]:
+        PLUGIN_HANDLES.append(ctypes.CDLL(os.path.join(directory, filename)))
+      elif filename == "__init__.py":
+        pass
+      else:
+        warnings.warn('Ignoring non-library in plugin directory: '
+                      f'{os.path.join(directory, filename)}', ImportWarning)
 
 _load_all_bundled_plugins()
 

--- a/python/mujoco/__init__.py
+++ b/python/mujoco/__init__.py
@@ -54,7 +54,15 @@ PLUGIN_HANDLES = []
 def _load_all_bundled_plugins():
   for directory, _, filenames in os.walk(PLUGINS_DIR):
     for filename in filenames:
-      PLUGIN_HANDLES.append(ctypes.CDLL(os.path.join(directory, filename)))
+        if os.path.splitext(filename)[-1] == ".so":
+            PLUGIN_HANDLES.append(ctypes.CDLL(os.path.join(directory, filename)))
+
+        elif filename == "__init__.py":
+            pass
+
+        else:
+            raise ValueError(f"Trying to load the plugin {os.path.join(directory, filename)}, "
+                             "which is not a shared library.")
 
 _load_all_bundled_plugins()
 


### PR DESCRIPTION
The loading of the plugins in `python/mujoco/__init__.py` can fail depending on the used build environment. When the described installation process is followed, everything works fine. However, some build environments can "generously" add `__init__.py` files to all sub-directories, which causes the error `OSError: [...]/mujoco/site-packages/mujoco/plugin/__init__.py: invalid ELF header` as the added `plugin/__init__.py` file is passed to `ctypes.CDLL(...)`. 
