### PR TITLE
Fix `mj_sizeModel`

### DIFF
--- a/src/engine/engine_io.c
+++ b/src/engine/engine_io.c
@@ -803,8 +803,19 @@ void mj_deleteModel(mjModel* m) {
 
 // size of buffer needed to hold model
 int mj_sizeModel(const mjModel* m) {
-  return sizeof(int)*(4+getnint()) + sizeof(mjOption) +
-         sizeof(mjVisual) + sizeof(mjStatistic) + m->nbuffer;
+  int size = (
+    sizeof(int)*(4+getnint())
+    + sizeof(mjOption)
+    + sizeof(mjVisual)
+    + sizeof(mjStatistic));
+
+MJMODEL_POINTERS_PREAMBLE(m)
+#define X(type, name, nr, nc)         \
+  size += sizeof(type)*(m->nr)*(nc);
+  MJMODEL_POINTERS
+#undef X
+
+  return size;
 }
 
 

--- a/test/engine/engine_io_test.cc
+++ b/test/engine/engine_io_test.cc
@@ -18,7 +18,11 @@
 
 #include <array>
 #include <climits>
+#include <cstdio>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
 #include <string>
 
 #include <gmock/gmock.h>
@@ -45,6 +49,34 @@ mjModel PartialModel(const mjModel* m) {
   #undef X
   partial_model.nbuffer = 0;
   return partial_model;
+}
+
+TEST_F(EngineIoTest, VerifySizeModel) {
+  constexpr char xml[] = R"(
+  <mujoco>
+    <worldbody>
+      <body>
+        <joint/>
+        <geom size="1"/>
+      </body>
+    </worldbody>
+  </mujoco>
+  )";
+
+  std::array<char, 1024> error;
+  mjModel* model = LoadModelFromString(xml, error.data(), error.size());
+  ASSERT_THAT(model, NotNull()) << "Failed to load model: " << error.data();
+
+  std::filesystem::path temp_file = (
+    std::filesystem::temp_directory_path() / "model.mjb");
+
+  mj_saveModel(model, temp_file.string().c_str(), NULL, 0);
+
+  std::uintmax_t file_size = std::filesystem::file_size(temp_file);
+
+  std::filesystem::remove(temp_file);
+
+  EXPECT_EQ(file_size, mj_sizeModel(model));
 }
 
 TEST_F(EngineIoTest, MakeDataFromPartialModel) {

--- a/test/engine/engine_io_test.cc
+++ b/test/engine/engine_io_test.cc
@@ -73,10 +73,12 @@ TEST_F(EngineIoTest, VerifySizeModel) {
   mj_saveModel(model, temp_file.string().c_str(), NULL, 0);
 
   std::uintmax_t file_size = std::filesystem::file_size(temp_file);
+  int model_size = mj_sizeModel(model);
 
   std::filesystem::remove(temp_file);
+  mj_deleteModel(model);
 
-  EXPECT_EQ(file_size, mj_sizeModel(model));
+  EXPECT_EQ(file_size, model_size);
 }
 
 TEST_F(EngineIoTest, MakeDataFromPartialModel) {


### PR DESCRIPTION
Before these changes, the included `EngineIoTest.VerifySizeModel` test fails with the following:
```
mujoco/test/engine/engine_io_test.cc:79: Failure
Expected equality of these values:
  file_size
    Which is: 2416
  mj_sizeModel(model)
    Which is: 6488
```

With the fix, the test passes.