### PR TITLE
Fix the effective time constant function for muscle

### DIFF
--- a/doc/modeling.rst
+++ b/doc/modeling.rst
@@ -772,7 +772,7 @@ are two time constants specified with the attribute timeconst, namely :math:`\te
 <https://doi.org/10.1115/1.4023390>`__, the effective time constant :math:`\tau` is then computed at runtime as:
 
 .. math::
-   \tau(\texttt{ctrl}-\texttt{act}) =
+   \tau(\texttt{ctrl}, \texttt{act}) =
    \begin{cases}
       \tau_\text{act} \cdot (0.5 + 1.5\cdot\texttt{act}) & \texttt{ctrl}-\texttt{act} \gt 0 \\
       \tau_\text{deact} / (0.5 + 1.5\cdot\texttt{act}) & \texttt{ctrl} - \texttt{act} \leq 0


### PR DESCRIPTION
At the latest docs of modeling section, the effective time constant function for muscle just has one parameter, ``ctrl-act``. But ``act``    is used in this function. So, I think it should be $\tau(\text{ctrl}, \text{act})$ instead of $\tau(\text{ctrl} - \text{act})$.

![image](https://github.com/deepmind/mujoco/assets/37178760/d682130a-7bd3-4fb4-a978-e948753a3c23)
