### PR TITLE
Fix compilation when using Windows SDK < 10.0.22000

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,13 +94,11 @@ jobs:
               -DMUJOCO_HARDEN:BOOL=ON
             tmpdir: "/tmp"
           - os: windows-2022
-            cmake_args: >-
-              -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
+            cmake_args: ""
             cmake_build_args: "-- -m"
             tmpdir: "C:/Temp"
           - os: windows-2019
-            cmake_args: >-
-              -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
+            cmake_args: ""
             cmake_build_args: "-- -m"
             tmpdir: "C:/Temp"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,13 @@ if(APPLE AND MUJOCO_BUILD_MACOS_FRAMEWORKS)
   )
 endif()
 
+# This code is a workaround for https://github.com/deepmind/mujoco/issues/862
+# Once it can be assumed that no users uses a Windows SDK < 10.0.22000
+# we can drop this code
+if(MSVC AND CMAKE_SYSTEM_VERSION VERSION_LESS 10.0.22000)
+  target_compile_definitions(mujoco PRIVATE MUJOCO_WINSDK_NO_STDALIGN_H)
+endif()
+
 # Add a namespace alias to mujoco to be used by the examples.
 # This simulates the install interface when building with sources.
 add_library(mujoco::mujoco ALIAS mujoco)

--- a/src/engine/engine_collision_driver.h
+++ b/src/engine/engine_collision_driver.h
@@ -29,7 +29,11 @@ extern "C" {
 #error "Compiler does not support C11."
 #endif
 #else
+// This ifndef is workaround for https://github.com/deepmind/mujoco/issues/862
+// Remove once we can assume that no one uses WIN SDK < 10.0.22000
+#ifndef MUJOCO_WINSDK_NO_STDALIGN_H
 #include <stdalign.h>
+#endif
 #endif
 
 struct mjCollisionTree_ {


### PR DESCRIPTION
As discussed in https://github.com/deepmind/mujoco/issues/862#issuecomment-1601321623 .

In a nutshell, some users in some configurations experienced the error:
~~~
 F:\develop\kit-extension\kit-extension-template-cpp\mujoco\src\engine/engine_collision_driver.h(32,1): fatal error C1083: Cannot open include file: 'stdalign.h': No such file or directory
~~~

This was happening on different Visual Studio 2019 versions, without a clear dependency on the version of Visual Studio 2019. Why this was happening? Because the C standard library header are not provided by the compiled (Visual Studio), but rather by the Windows SDK headers, so this was happening depending on the version of the Windows SDK used.

For example, this was happening also on GitHub Actions, in which all the following versions of Windows SDK are provided:

~~~
ls /c/Program\ Files\ \(x86\)/Windows\ Kits/10/Include
10.0.10240.0
10.0.14393.0
10.0.16299.0
10.0.17134.0
10.0.17763.0
10.0.18362.0
10.0.19041.0
10.0.20348.0
10.0.22000.0
10.0.22621.0
~~~

By default, CMake selected the SDK version `10.0.17763.0` in which `stdalign.h` is missing, while the MuJoCo CI was forcing the use of the latest available Windows SDK passing the CMake option `-DCMAKE_SYSTEM_VERSION="10.0.22621.0"`. However, how does CMake selected the SDK version to use?

It is not explicitly documented, but inspecting the CMake's code:
* https://gitlab.kitware.com/cmake/cmake/-/blob/v3.26.4/Modules/CMakeDetermineSystem.cmake?ref_type=tags#L176
* https://gitlab.kitware.com/cmake/cmake/-/blob/master/Source/cmGlobalGenerator.cxx#L643

It is possible to understand that the SDK used is the one matching the version of the system, i.e. the one that for example you can obtain via the `winver` command. Indeed, if one checks the Windows version of the windows-2019 GitHub Action image in https://github.com/actions/runner-images/blob/59f713795a1747e8ccbdc103a3942bfa2160100b/images/win/Windows2019-Readme.md, it is possible to see that it is `10.0.17763`.

As a workaround for this problem, I added some CMake + C code that does not include `stdalign.h` if the Win SDK version is <= 10.0.22000 . However, I am not fully satisfied by this, so we can either not do this and just tell to users that have this problem to manually specify via `CMAKE_SYSTEM_VERSION` a new enough SDK version.