### PR TITLE
Replace O2MConverter with improved MyoConverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ These packages give users of various languages access to MuJoCo functionality:
 
 ### Converters
 
-- **OpenSim**: [O2MConverter](https://github.com/aikkala/O2MConverter) converts
-  openSIM models to MJCF.
+- **OpenSim**: [MyoConverter](https://github.com/MyoHub/myoconverter) converts
+  OpenSim models to MJCF.
 - **SDFormat**: [gz-mujoco](https://github.com/gazebosim/gz-mujoco/) is a
   two-way SDFormat <-> MJCF conversion tool.
 - **OBJ**: [obj2mjcf](https://github.com/kevinzakka/obj2mjcf)


### PR DESCRIPTION
Update README with a reference to MyoConverter, the new and improved OpenSim to MJCF model converter